### PR TITLE
Refactor Wi-Fi 6 GHz support

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -1,9 +1,18 @@
 {
-    until [[ "$(getprop sys.boot_completed)" == "1" ]]; do
-        sleep 15
+    while [ "$(getprop sys.boot_completed)" != "1" ]; do
+        sleep 1
     done
 
-    cmd wifi force-country-code enabled GB
+    # cmd wifi: works in modern Android
+    cmd wifi force-country-code enabled AU
+    # prop: works in legacy Android
+    resetprop ro.boot.wificountrycode AU
+    resetprop wifi.country AU
+    # Force enable 6GHz overlay configs if possible
+    # These are often device specific but setting them doesn't hurt
+    resetprop ro.wifi.6ghz.enabled true
+    resetprop config.disable_wifi_6ghz false
+
     setprop gsm.operator.iso-country us,us
     setprop gsm.sim.operator.iso-country us,us
 }&

--- a/system.prop
+++ b/system.prop
@@ -40,6 +40,10 @@ persist.vendor.radio.mbn_load_flag=3
 persist.vendor.radio.mbn_wait_s=60
 persist.vendor.radio.redir_party_num=1
 
+# Force Wi-Fi 6GHz for some devices
+ro.wifi.6ghz.enabled=true
+config.disable_wifi_6ghz=false
+
 # Others
 ril.subscription.types=RUIM
 # RO: 0 no support - 1 nsa - 2 sa - 3 nsa+sa


### PR DESCRIPTION
The PR changes the following

- Instead of a 15-second interval, the PR now uses a 1-second interval for boot complete detect check, same in https://github.com/canoziia/magisk-module-wifi7/blob/main/service.sh
- Changed the Wi-Fi country from GB to AU
  - According to my test on Pixel 7, the working Wi-Fi country code for 6 GHz (Wi-Fi 6E) would be: NL, DE, JP, AU
  - According to my test on Pixel 7, the non-working Wi-Fi country code would be: US, CA, EU
  - See also https://github.com/AndroPlus-org/magisk-module-wifi7/issues/8
  - According to [the wireless DB](https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt), `AU` provides maximum allowed radio power (a bit higher than `GB` here), which should allow even faster Wi-Fi speed with a properly configured Access Point.
- Use more system props for unlocking 6 GHz on legacy Android devices, and some specific OEM Android devices
  - Properly does not apply for modern Pixel, but doesn't hurt to add anyway